### PR TITLE
Create base template for sub-sections of knode.io

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+
+  <head>
+    <meta charset='utf-8' />
+    <meta http-equiv="X-UA-Compatible" content="chrome=1" />
+    <meta name="description" content="Meetups: A place to put info about your local meetup. Anything node-flavored JS welcome!" />
+
+    <link rel="stylesheet" type="text/css" media="screen" href="stylesheets/stylesheet.css">
+    <link rel="stylesheet" href="http://knode.io/style/assets/css/bootstrap.min.css" />
+    <link rel="stylesheet" href="http://knode.io/style/assets/css/ostrich-sans/stylesheet.css" />
+    <link rel="stylesheet" href="http://knode.io/style/assets/css/main.css" />
+    <link rel="stylesheet" media="screen" href="stylesheets/site-specific.css">
+
+    <title>Meetups</title>
+  </head>
+
+  <body>
+    <h1>Meetups</h1>
+    <!--<div>MAP PLACEHOLDER</div>--> 
+    <section>
+        <article>
+            <!-- This is where the listings go. They will be sorted in alphabetical order by city.-->
+            <h3>Portland, OR</h3>
+                <!-- within each city directory, list the meetups in alphabetical order by group name-->
+                <ul>
+                    <!--Please map these to the markdown we require for input-->            
+                    <h5><a href="http://pdxnode.org">PDXNode</a></h5>
+                        <a href="https://github.com/PDXNode/pdxnode">Contribute</a>
+                        <li>Organizers: Ben, Tracy, Chris, Wraithan, Mean Dave, Dave, Adam, Nick, Adron, Justin</li>
+                        <li>Bi-monthly presentation and hack nights. We also hold workshops & nodebots events</li>
+                        <li>Talks are submitted via PR and reviewed by organizers. Organizers seek out and encourage talks from community members.</li>
+                        <li>#pdxnode on freenode.irc.net</li>
+                        <li><a href="https://github.com/PDXNode/pdxnode/blob/master/code-of-conduct.md">Code of Conduct</a></li>
+                </ul>
+        </article>
+    </section>
+  </body>
+
+</html>        
+       

--- a/templates/base.html
+++ b/templates/base.html
@@ -33,6 +33,18 @@
                         <li>#pdxnode on freenode.irc.net</li>
                         <li><a href="https://github.com/PDXNode/pdxnode/blob/master/code-of-conduct.md">Code of Conduct</a></li>
                 </ul>
+            <h3>AnotherCity, USA</h3>
+                <!-- within each city directory, list the meetups in alphabetical order by group name-->
+                <ul>
+                    <!--Please map these to the markdown we require for input-->            
+                    <h5><a href="http://google.com">AwesomeGroup</a></h5>
+                        <a href="https://github.com/PDXNode/">Contribute</a>
+                        <li>Organizers: The Carebears</li>
+                        <li>Bi-monthly presentation and hack nights. We also hold workshops & nodebots events</li>
+                        <li>Talks are submitted via PR and reviewed by organizers. Organizers seek out and encourage talks from community members.</li>
+                        <li>#winning on freenode.irc.net</li>
+                        <li><a href="https://github.com/PDXNode/pdxnode/blob/master/code-of-conduct.md">Code of Conduct</a></li>
+                </ul>
         </article>
     </section>
   </body>


### PR DESCRIPTION
This is the starting base.html for knode.io sub-sections. We need to determine what map we'd like to use and the styling will need further guidance.

Once we have the context in place, I'll move forward(or need help) with rendering the templates and adding the templating into the html. When that happens, I will breakout the html into list.html as well to keep the base nice and clean for reuse.

The idea is for us to be able to reuse these. 
